### PR TITLE
Fix Matching Configuration check and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .idea/
 .tox/
+.pytest_cache/

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -323,19 +323,11 @@ def _files_match_settings(conanfile, folder):
     has_linux = _has_files_with_extensions(folder, linux_extensions)
     has_macos = _has_files_with_extensions(folder, macos_extensions)
     os = _get_os(conanfile)
-    print("os: ", os)
-    print("has_header: ", has_header)
-    print("has_visual: ", has_visual)
-    print("has_mingw: ", has_mingw)
-    print("has_linux: ", has_linux)
-    print("has_macos: ", has_macos)
 
     if not has_header and not has_visual and not has_mingw and not has_linux and not has_macos:
         # empty package?
-        print("empty package?")
         return False
     if _is_recipe_header_only(conanfile):
-        print("header only pkg id")
         return has_header and not has_visual and not has_mingw and not has_linux and not has_macos
     if os == "Windows":
         if conanfile.settings.get_safe("compiler") == "Visual Studio":
@@ -348,7 +340,6 @@ def _files_match_settings(conanfile, folder):
         return has_macos and not has_visual and not has_mingw and not has_linux
     if os is None:
         # Header only
-        print("header only")
         return has_header and not has_visual and not has_mingw and not has_linux and not has_macos
     return False
 

--- a/tests/test_hooks/test_conan-center.py
+++ b/tests/test_hooks/test_conan-center.py
@@ -89,7 +89,6 @@ class ConanCenterTests(ConanClientTestCase):
     def package_id(self):
         self.info.header_only()
         """
-        print("CONANFILE", cf)
         tools.save('conanfile.py', content=cf)
         tools.save('file.h', content="")
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
@@ -129,12 +128,10 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
         self.assertIn("[SHARED ARTIFACTS] OK", output)
-        print(output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
         tools.save('header.h', content="")
-        print(self.conanfile_header_only)
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
         self.assertIn("[RECIPE METADATA] OK", output)
         self.assertIn("[HEADER ONLY] OK", output)
@@ -150,58 +147,55 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
         self.assertIn("[SHARED ARTIFACTS] OK", output)
 
-    # def test_conanfile_header_only_with_settings(self):
-    #     print(self.conanfile_header_only_with_settings)
-    #     tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
-    #     tools.save('header.h', content="")
-    #     output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-    #     print(output)
-    #     self.assertIn("[RECIPE METADATA] OK", output)
-    #     self.assertIn("[HEADER ONLY] OK", output)
-    #     self.assertIn("[NO COPY SOURCE] OK", output)
-    #     self.assertIn("[FPIC OPTION] OK", output)
-    #     self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
-    #     self.assertIn("[VERSION RANGES] OK", output)
-    #     self.assertIn("[LIBCXX] OK", output)
-    #     self.assertIn("[MATCHING CONFIGURATION] OK", output)
-    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
-    #     self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
-    #     self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
-    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
-    #
-    # def test_conanfile_installer(self):
-    #     tools.save('conanfile.py', content=self.conanfile_installer)
-    #     output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-    #     self.assertIn("[RECIPE METADATA] OK", output)
-    #     self.assertIn("[HEADER ONLY] OK", output)
-    #     self.assertIn("[NO COPY SOURCE] OK", output)
-    #     self.assertIn("[FPIC OPTION] OK", output)
-    #     self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
-    #     self.assertIn("[VERSION RANGES] OK", output)
-    #     self.assertIn("[LIBCXX] OK", output)
-    #     self.assertIn("ERROR: [MATCHING CONFIGURATION] Built artifacts does not match the settings",
-    #                   output)
-    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
-    #     self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
-    #     self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
-    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
-    #
-    # def test_regular_folder_size(self):
-    #     tools.save('conanfile.py', content=self.conanfile_installer)
-    #     output = self.conan(['export', '.', 'name/version@user/channel'])
-    #     self.assertIn("[RECIPE FOLDER SIZE] OK", output)
-    #     self.assertNotIn("ERROR: [RECIPE FOLDER SIZE]", output)
-    #
-    # def test_larger_folder_size(self):
-    #     content = " ".join(["test_recipe_folder_larger_size" for it in range(1048576)])
-    #     tools.save('conanfile.py', content=self.conanfile_installer)
-    #     tools.save('big_file', content=content)
-    #     output = self.conan(['export', '.', 'name/version@user/channel'])
-    #     self.assertIn("ERROR: [RECIPE FOLDER SIZE] The size of your recipe folder", output)
-    #
-    # def test_custom_folder_size(self):
-    #     with tools.environment_append({"CONAN_MAX_RECIPE_FOLDER_SIZE_KB": "0"}):
-    #         content = " ".join(["test_recipe_folder_larger_size" for it in range(1048576)])
-    #         tools.save('conanfile.py', content=self.conanfile_installer)
-    #         output = self.conan(['export', '.', 'name/version@user/channel'])
-    #         self.assertIn("ERROR: [RECIPE FOLDER SIZE] The size of your recipe folder", output)
+    def test_conanfile_header_only_with_settings(self):
+        tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
+        tools.save('header.h', content="")
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        self.assertIn("[RECIPE METADATA] OK", output)
+        self.assertIn("[HEADER ONLY] OK", output)
+        self.assertIn("[NO COPY SOURCE] OK", output)
+        self.assertIn("[FPIC OPTION] OK", output)
+        self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
+        self.assertIn("[VERSION RANGES] OK", output)
+        self.assertIn("[LIBCXX] OK", output)
+        self.assertIn("[MATCHING CONFIGURATION] OK", output)
+        self.assertIn("[SHARED ARTIFACTS] OK", output)
+        self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
+        self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
+        self.assertIn("[SHARED ARTIFACTS] OK", output)
+
+    def test_conanfile_installer(self):
+        tools.save('conanfile.py', content=self.conanfile_installer)
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        self.assertIn("[RECIPE METADATA] OK", output)
+        self.assertIn("[HEADER ONLY] OK", output)
+        self.assertIn("[NO COPY SOURCE] OK", output)
+        self.assertIn("[FPIC OPTION] OK", output)
+        self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
+        self.assertIn("[VERSION RANGES] OK", output)
+        self.assertIn("[LIBCXX] OK", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION] Built artifacts does not match the settings",
+                      output)
+        self.assertIn("[SHARED ARTIFACTS] OK", output)
+        self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
+        self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
+        self.assertIn("[SHARED ARTIFACTS] OK", output)
+
+    def test_regular_folder_size(self):
+        tools.save('conanfile.py', content=self.conanfile_installer)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[RECIPE FOLDER SIZE] OK", output)
+        self.assertNotIn("ERROR: [RECIPE FOLDER SIZE]", output)
+
+    def test_larger_folder_size(self):
+        content = " ".join(["test_recipe_folder_larger_size" for it in range(1048576)])
+        tools.save('conanfile.py', content=self.conanfile_installer)
+        tools.save('big_file', content=content)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [RECIPE FOLDER SIZE] The size of your recipe folder", output)
+
+    def test_custom_folder_size(self):
+        with tools.environment_append({"CONAN_MAX_RECIPE_FOLDER_SIZE_KB": "0"}):
+            tools.save('conanfile.py', content=self.conanfile_installer)
+            output = self.conan(['export', '.', 'name/version@user/channel'])
+            self.assertIn("ERROR: [RECIPE FOLDER SIZE] The size of your recipe folder", output)

--- a/tests/test_hooks/test_conan-center.py
+++ b/tests/test_hooks/test_conan-center.py
@@ -20,6 +20,9 @@ class ConanCenterTests(ConanClientTestCase):
             description = "whatever"
             exports_sources = "header.h"
             {placeholder}
+
+            def package(self):
+                self.copy("*", dst="include")
         """)
     conanfile_header_only_with_settings = textwrap.dedent("""\
         from conans import ConanFile
@@ -47,7 +50,7 @@ class ConanCenterTests(ConanClientTestCase):
             def package(self):
                 self.copy("*")
     """)
-    conanfile_header_only = conanfile_base.format(placeholder='pass')
+    conanfile_header_only = conanfile_base.format(placeholder='')
     conanfile_installer = conanfile_base.format(placeholder='settings = "os_build"')
     conanfile = conanfile_base.format(placeholder='settings = "os"')
 
@@ -83,9 +86,10 @@ class ConanCenterTests(ConanClientTestCase):
                                               settings="settings = 'os', 'compiler', 'arch', "
                                                        "'build_type'")
         cf = cf + """
-        def package_id(self):
-            self.info.header_only()
+    def package_id(self):
+        self.info.header_only()
         """
+        print("CONANFILE", cf)
         tools.save('conanfile.py', content=cf)
         tools.save('file.h', content="")
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
@@ -110,40 +114,41 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertNotIn("[MATCHING CONFIGURATION] OK", output)
         self.assertIn("ERROR: [MATCHING CONFIGURATION]", output)
 
-    # def test_conanfile(self):
-    #     tools.save('conanfile.py', content=self.conanfile)
-    #     output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-    #     self.assertIn("[RECIPE METADATA] OK", output)
-    #     self.assertIn("[HEADER ONLY] OK", output)
-    #     self.assertIn("[NO COPY SOURCE] OK", output)
-    #     self.assertIn("[FPIC OPTION] OK", output)
-    #     self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
-    #     self.assertIn("[VERSION RANGES] OK", output)
-    #     self.assertIn("[LIBCXX] OK", output)
-    #     self.assertIn("[MATCHING CONFIGURATION] OK", output)
-    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
-    #     self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
-    #     self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
-    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
-    #     print(output)
+    def test_conanfile(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        self.assertIn("[RECIPE METADATA] OK", output)
+        self.assertIn("[HEADER ONLY] OK", output)
+        self.assertIn("[NO COPY SOURCE] OK", output)
+        self.assertIn("[FPIC OPTION] OK", output)
+        self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
+        self.assertIn("[VERSION RANGES] OK", output)
+        self.assertIn("[LIBCXX] OK", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION]", output)  # Empty package
+        self.assertIn("[SHARED ARTIFACTS] OK", output)
+        self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
+        self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
+        self.assertIn("[SHARED ARTIFACTS] OK", output)
+        print(output)
 
-    # def test_conanfile_header_only(self):
-    #     tools.save('conanfile.py', content=self.conanfile_header_only)
-    #     tools.save('header.h', content="")
-    #     output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-    #     self.assertIn("[RECIPE METADATA] OK", output)
-    #     self.assertIn("[HEADER ONLY] OK", output)
-    #     self.assertIn("[NO COPY SOURCE] This recipe seems to be for a header only", output)
-    #     self.assertIn("[FPIC OPTION] OK", output)
-    #     self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
-    #     self.assertIn("[VERSION RANGES] OK", output)
-    #     self.assertIn("[LIBCXX] OK", output)
-    #     self.assertIn("[MATCHING CONFIGURATION] OK", output)
-    #     self.assertNotIn("ERROR: [MATCHING CONFIGURATION]", output)
-    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
-    #     self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
-    #     self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
-    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+    def test_conanfile_header_only(self):
+        tools.save('conanfile.py', content=self.conanfile_header_only)
+        tools.save('header.h', content="")
+        print(self.conanfile_header_only)
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        self.assertIn("[RECIPE METADATA] OK", output)
+        self.assertIn("[HEADER ONLY] OK", output)
+        self.assertIn("[NO COPY SOURCE] This recipe seems to be for a header only", output)
+        self.assertIn("[FPIC OPTION] OK", output)
+        self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
+        self.assertIn("[VERSION RANGES] OK", output)
+        self.assertIn("[LIBCXX] OK", output)
+        self.assertIn("[MATCHING CONFIGURATION] OK", output)
+        self.assertNotIn("ERROR: [MATCHING CONFIGURATION]", output)
+        self.assertIn("[SHARED ARTIFACTS] OK", output)
+        self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
+        self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
+        self.assertIn("[SHARED ARTIFACTS] OK", output)
 
     # def test_conanfile_header_only_with_settings(self):
     #     print(self.conanfile_header_only_with_settings)

--- a/tests/test_hooks/test_conan-center.py
+++ b/tests/test_hooks/test_conan-center.py
@@ -2,8 +2,10 @@
 
 import os
 import textwrap
+import platform
 
 from conans import tools
+from parameterized import parameterized
 
 from tests.utils.test_cases.conan_client import ConanClientTestCase
 
@@ -16,8 +18,35 @@ class ConanCenterTests(ConanClientTestCase):
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
+            exports_sources = "header.h"
             {placeholder}
         """)
+    conanfile_header_only_with_settings = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            url = "fake_url.com"
+            license = "fake_license"
+            description = "whatever"
+            exports_sources = "header.h"
+            settings = "os", "compiler", "arch", "build_type"
+
+            def package_id(self):
+                self.info.header_only()
+        """)
+    conanfile_match_conf = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            url = "fake_url.com"
+            license = "fake_license"
+            description = "whatever"
+            exports_sources = "file.{extension}"
+            {settings}
+
+            def package(self):
+                self.copy("*")
+    """)
     conanfile_header_only = conanfile_base.format(placeholder='pass')
     conanfile_installer = conanfile_base.format(placeholder='settings = "os_build"')
     conanfile = conanfile_base.format(placeholder='settings = "os"')
@@ -28,72 +57,146 @@ class ConanCenterTests(ConanClientTestCase):
                                                    'conan-center')})
         return kwargs
 
-    def test_conanfile(self):
+    def test_no_duplicated_messages(self):
         tools.save('conanfile.py', content=self.conanfile)
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-        self.assertIn("[RECIPE METADATA] OK", output)
-        self.assertIn("[HEADER ONLY] OK", output)
-        self.assertIn("[NO COPY SOURCE] OK", output)
-        self.assertIn("[FPIC OPTION] OK", output)
-        self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
-        self.assertIn("[VERSION RANGES] OK", output)
-        self.assertIn("[LIBCXX] OK", output)
-        self.assertIn("[MATCHING CONFIGURATION] OK", output)
-        self.assertIn("[SHARED ARTIFACTS] OK", output)
         self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
-        self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
-        self.assertIn("[SHARED ARTIFACTS] OK", output)
-        print(output)
+        self.assertNotIn("[PACKAGE LICENSE] OK", output)
 
-    def test_conanfile_header_only(self):
-        tools.save('conanfile.py', content=self.conanfile_header_only)
+    @parameterized.expand([("lib", "Windows"), ("so", "Darwin"), ("so", "Linux")])
+    def test_matching_configuration(self, extension, system_name):
+        cf = self.conanfile_match_conf.format(extension=extension,
+                                              settings="settings = 'os', 'compiler', 'arch', "
+                                                       "'build_type'")
+        tools.save('conanfile.py', content=cf)
+        tools.save('file.%s' % extension, content="")
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-        self.assertIn("[RECIPE METADATA] OK", output)
-        self.assertIn("[HEADER ONLY] OK", output)
-        self.assertIn("[NO COPY SOURCE] This recipe seems to be for a header only", output)
-        self.assertIn("[FPIC OPTION] OK", output)
-        self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
-        self.assertIn("[VERSION RANGES] OK", output)
-        self.assertIn("[LIBCXX] OK", output)
-        self.assertIn("[MATCHING CONFIGURATION] OK", output)
-        self.assertIn("[SHARED ARTIFACTS] OK", output)
-        self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
-        self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
-        self.assertIn("[SHARED ARTIFACTS] OK", output)
+        if platform.system() == system_name:
+            self.assertIn("[MATCHING CONFIGURATION] OK", output)
+            self.assertNotIn("ERROR: [MATCHING CONFIGURATION]", output)
+        else:
+            self.assertNotIn("[MATCHING CONFIGURATION] OK", output)
+            self.assertIn("ERROR: [MATCHING CONFIGURATION]", output)
 
-    def test_conanfile_installer(self):
-        tools.save('conanfile.py', content=self.conanfile_installer)
+    def test_matching_configuration_header_only_package_id(self):
+        cf = self.conanfile_match_conf.format(extension="h",
+                                              settings="settings = 'os', 'compiler', 'arch', "
+                                                       "'build_type'")
+        cf = cf + """
+        def package_id(self):
+            self.info.header_only()
+        """
+        tools.save('conanfile.py', content=cf)
+        tools.save('file.h', content="")
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-        self.assertIn("[RECIPE METADATA] OK", output)
-        self.assertIn("[HEADER ONLY] OK", output)
-        self.assertIn("[NO COPY SOURCE] OK", output)
-        self.assertIn("[FPIC OPTION] OK", output)
-        self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
-        self.assertIn("[VERSION RANGES] OK", output)
-        self.assertIn("[LIBCXX] OK", output)
-        self.assertIn("ERROR: [MATCHING CONFIGURATION] Built artifacts does not match the settings",
-                      output)
-        self.assertIn("[SHARED ARTIFACTS] OK", output)
-        self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
-        self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
-        self.assertIn("[SHARED ARTIFACTS] OK", output)
+        self.assertIn("[MATCHING CONFIGURATION] OK", output)
+        self.assertNotIn("ERROR: [MATCHING CONFIGURATION]", output)
 
-    def test_regular_folder_size(self):
-        tools.save('conanfile.py', content=self.conanfile_installer)
-        output = self.conan(['export', '.', 'name/version@user/channel'])
-        self.assertIn("[RECIPE FOLDER SIZE] OK", output)
-        self.assertNotIn("ERROR: [RECIPE FOLDER SIZE]", output)
+    def test_matching_configuration_header_only(self):
+        cf = self.conanfile_match_conf.format(extension="h",
+                                              settings="")
+        tools.save('conanfile.py', content=cf)
+        tools.save('file.h', content="")
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        self.assertIn("[MATCHING CONFIGURATION] OK", output)
+        self.assertNotIn("ERROR: [MATCHING CONFIGURATION]", output)
 
-    def test_larger_folder_size(self):
-        content = " ".join(["test_recipe_folder_larger_size" for it in range(1048576)])
-        tools.save('conanfile.py', content=self.conanfile_installer)
-        tools.save('big_file', content=content)
-        output = self.conan(['export', '.', 'name/version@user/channel'])
-        self.assertIn("ERROR: [RECIPE FOLDER SIZE] The size of your recipe folder", output)
+    def test_matching_configuration_empty(self):
+        cf = self.conanfile_match_conf.format(extension="",
+                                              settings="settings = 'os', 'compiler', 'arch', "
+                                                       "'build_type'")
+        tools.save('conanfile.py', content=cf)
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        self.assertNotIn("[MATCHING CONFIGURATION] OK", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION]", output)
 
-    def test_custom_folder_size(self):
-        with tools.environment_append({"CONAN_MAX_RECIPE_FOLDER_SIZE_KB": "0"}):
-            content = " ".join(["test_recipe_folder_larger_size" for it in range(1048576)])
-            tools.save('conanfile.py', content=self.conanfile_installer)
-            output = self.conan(['export', '.', 'name/version@user/channel'])
-            self.assertIn("ERROR: [RECIPE FOLDER SIZE] The size of your recipe folder", output)
+    # def test_conanfile(self):
+    #     tools.save('conanfile.py', content=self.conanfile)
+    #     output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+    #     self.assertIn("[RECIPE METADATA] OK", output)
+    #     self.assertIn("[HEADER ONLY] OK", output)
+    #     self.assertIn("[NO COPY SOURCE] OK", output)
+    #     self.assertIn("[FPIC OPTION] OK", output)
+    #     self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
+    #     self.assertIn("[VERSION RANGES] OK", output)
+    #     self.assertIn("[LIBCXX] OK", output)
+    #     self.assertIn("[MATCHING CONFIGURATION] OK", output)
+    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+    #     self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
+    #     self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
+    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+    #     print(output)
+
+    # def test_conanfile_header_only(self):
+    #     tools.save('conanfile.py', content=self.conanfile_header_only)
+    #     tools.save('header.h', content="")
+    #     output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+    #     self.assertIn("[RECIPE METADATA] OK", output)
+    #     self.assertIn("[HEADER ONLY] OK", output)
+    #     self.assertIn("[NO COPY SOURCE] This recipe seems to be for a header only", output)
+    #     self.assertIn("[FPIC OPTION] OK", output)
+    #     self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
+    #     self.assertIn("[VERSION RANGES] OK", output)
+    #     self.assertIn("[LIBCXX] OK", output)
+    #     self.assertIn("[MATCHING CONFIGURATION] OK", output)
+    #     self.assertNotIn("ERROR: [MATCHING CONFIGURATION]", output)
+    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+    #     self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
+    #     self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
+    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+
+    # def test_conanfile_header_only_with_settings(self):
+    #     print(self.conanfile_header_only_with_settings)
+    #     tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
+    #     tools.save('header.h', content="")
+    #     output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+    #     print(output)
+    #     self.assertIn("[RECIPE METADATA] OK", output)
+    #     self.assertIn("[HEADER ONLY] OK", output)
+    #     self.assertIn("[NO COPY SOURCE] OK", output)
+    #     self.assertIn("[FPIC OPTION] OK", output)
+    #     self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
+    #     self.assertIn("[VERSION RANGES] OK", output)
+    #     self.assertIn("[LIBCXX] OK", output)
+    #     self.assertIn("[MATCHING CONFIGURATION] OK", output)
+    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+    #     self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
+    #     self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
+    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+    #
+    # def test_conanfile_installer(self):
+    #     tools.save('conanfile.py', content=self.conanfile_installer)
+    #     output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+    #     self.assertIn("[RECIPE METADATA] OK", output)
+    #     self.assertIn("[HEADER ONLY] OK", output)
+    #     self.assertIn("[NO COPY SOURCE] OK", output)
+    #     self.assertIn("[FPIC OPTION] OK", output)
+    #     self.assertIn("[FPIC MANAGEMENT] 'fPIC' option not found", output)
+    #     self.assertIn("[VERSION RANGES] OK", output)
+    #     self.assertIn("[LIBCXX] OK", output)
+    #     self.assertIn("ERROR: [MATCHING CONFIGURATION] Built artifacts does not match the settings",
+    #                   output)
+    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+    #     self.assertIn("ERROR: [PACKAGE LICENSE] No 'licenses' folder found in package", output)
+    #     self.assertIn("[DEFAULT PACKAGE LAYOUT] OK", output)
+    #     self.assertIn("[SHARED ARTIFACTS] OK", output)
+    #
+    # def test_regular_folder_size(self):
+    #     tools.save('conanfile.py', content=self.conanfile_installer)
+    #     output = self.conan(['export', '.', 'name/version@user/channel'])
+    #     self.assertIn("[RECIPE FOLDER SIZE] OK", output)
+    #     self.assertNotIn("ERROR: [RECIPE FOLDER SIZE]", output)
+    #
+    # def test_larger_folder_size(self):
+    #     content = " ".join(["test_recipe_folder_larger_size" for it in range(1048576)])
+    #     tools.save('conanfile.py', content=self.conanfile_installer)
+    #     tools.save('big_file', content=content)
+    #     output = self.conan(['export', '.', 'name/version@user/channel'])
+    #     self.assertIn("ERROR: [RECIPE FOLDER SIZE] The size of your recipe folder", output)
+    #
+    # def test_custom_folder_size(self):
+    #     with tools.environment_append({"CONAN_MAX_RECIPE_FOLDER_SIZE_KB": "0"}):
+    #         content = " ".join(["test_recipe_folder_larger_size" for it in range(1048576)])
+    #         tools.save('conanfile.py', content=self.conanfile_installer)
+    #         output = self.conan(['export', '.', 'name/version@user/channel'])
+    #         self.assertIn("ERROR: [RECIPE FOLDER SIZE] The size of your recipe folder", output)


### PR DESCRIPTION
- Matching Configuration check was not detecting the packages with only executable files. Other cases like header only packages were not well managed either.

- Fixed double output in `raise_if_error` decorator: Was outputting both the error message and OK

- Included helper methods to check if a recipe is for header only

- Included helper methods to check for recipe settings

- Removed unneeded `content` in FOLDER SIZE TEST

- Added a bunch of tests