### PR TITLE
Check for version ranges

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1,5 +1,6 @@
 import fnmatch
 import inspect
+import re
 import os
 from logging import WARNING, ERROR, INFO, DEBUG, NOTSET
 
@@ -114,7 +115,6 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             out.warn("This recipe does not include an 'fPIC' option. Make sure you are using the "
                      "right casing")
         elif options and not settings and ("fPIC" in options or "shared" in options):
-
             out.error("This recipe has 'shared' or 'fPIC' options but does not declare any "
                       "settings")
 
@@ -136,8 +136,10 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("VERSION RANGES", output)
     def test(out):
-        for num, line in enumerate(conanfile_content.splitlines()):
-            if all([char in line for char in ("@", "[", "]")]):
+        # This regex takes advantage that a conan reference is always a string
+        vrange_match = re.compile(r'.*[\'"][a-zA-Z0-9_+.-]+\/\[.+\]@[a-zA-Z0-9_+.\/-]+[\'"].*')
+        for num, line in enumerate(conanfile_content.splitlines(), 1):
+            if vrange_match.match(line):
                 out.error("Possible use of version ranges, line %s:\n %s" % (num, line))
 
     @run_test("RECIPE FOLDER SIZE", output)

--- a/tests/test_hooks/conan-center/test_version_ranges.py
+++ b/tests/test_hooks/conan-center/test_version_ranges.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+
+import os
+import textwrap
+import unittest
+
+from conans import tools
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+here = os.path.dirname(__file__)
+
+
+class VersionRanges(ConanClientTestCase):
+    conanfile_match_conf = textwrap.dedent("""
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            requires = "name/version@user/channel"  # Do not use name/[>=1.0]@user/channel
+    """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(VersionRanges, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(here, '..', '..', '..', 'hooks', 'conan-center')})
+        return kwargs
+
+    def test_no_version_ranges(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class AConan(ConanFile):
+                requires = "name/version@user/channel"  # Do not use name/[>=1.0]@user/channel
+                # Because version ranges in comments are not used: name/[>=1.0]@user/channel
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@jgsogo/test'])
+        self.assertNotIn("Possible use of version ranges", output)
+
+    def test_version_ranges(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class AConan(ConanFile):
+                requires = "name/[>=1]@user/channel"
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@jgsogo/test'])
+        self.assertIn("Possible use of version ranges", output)
+
+    def test_version_ranges2(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class AConan(ConanFile):
+                def requirements(self):
+                    self.requires('name/[>=1,2.0, include_prerelease=True]@user/channel')
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@jgsogo/test'])
+        self.assertIn("Possible use of version ranges", output)
+
+    @unittest.expectedFailure
+    def test_string_in_comment(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+
+            class AConan(ConanFile):
+                # Although it is commented... "name/[>=1.0]@user/channel"
+                requires = "name/version@user/channel"
+                
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@jgsogo/test'])
+        self.assertIn("Possible use of version ranges", output)
+

--- a/tests/utils/conan_command.py
+++ b/tests/utils/conan_command.py
@@ -14,7 +14,7 @@ def conan_command(output_stream):
     conan_api, cache, user_io = Conan.factory()
     user_io.out._stream = output_stream
     outputer = CommandOutputer(user_io, cache)
-    if Version(conan_version) >= "1.16":
+    if Version(conan_version) >= "1.18":
         cmd = Command(conan_api)
     else:
         cmd = Command(conan_api, cache, user_io, outputer)


### PR DESCRIPTION
Improve checking of version ranges in a recipe: it uses a regex looking for a string reference with a version range expression (it will fail if such pattern is found in a comment, there is a test demonstrating it).

This PR also includes changes from upstream `master`.